### PR TITLE
Add chrome-web-store badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Available color names:
 | travis | ![](https://badgen.now.sh/travis/amio/micro-cors) | https://badgen.now.sh/travis/amio/micro-cors |
 | circleci | ![](https://badgen.now.sh/circleci/github/amio/now-go) | https://badgen.now.sh/circleci/github/amio/now-go |
 | appveyor | ![](https://badgen.now.sh/appveyor/github/gruntjs/grunt) | https://badgen.now.sh/appveyor/github/gruntjs/grunt |
+| chrome extension version | ![](http://badgen.now.sh/chrome-web-store/v/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | https://badgen.now.sh/chrome-web-store/v/ckkdlimhmcjmikdlpkmbgfkaikojcbjk
+| chrome extension users | ![](http://badgen.now.sh/chrome-web-store/users/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | https://badgen.now.sh/chrome-web-store/users/ckkdlimhmcjmikdlpkmbgfkaikojcbjk
+| chrome extension price | ![](http://badgen.now.sh/chrome-web-store/price/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | https://badgen.now.sh/chrome-web-store/price/ckkdlimhmcjmikdlpkmbgfkaikojcbjk
+| chrome extension rating | ![](http://badgen.now.sh/chrome-web-store/rating/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | https://badgen.now.sh/chrome-web-store/rating/ckkdlimhmcjmikdlpkmbgfkaikojcbjk
+| chrome extension stars | ![](http://badgen.now.sh/chrome-web-store/stars/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | https://badgen.now.sh/chrome-web-store/stars/ckkdlimhmcjmikdlpkmbgfkaikojcbjk
+| chrome extension rating count | ![](http://badgen.now.sh/chrome-web-store/rating-count/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | https://badgen.now.sh/chrome-web-store/rating-count/ckkdlimhmcjmikdlpkmbgfkaikojcbjk
 
 ## About
 

--- a/libs/live-fns/_index.js
+++ b/libs/live-fns/_index.js
@@ -1,5 +1,7 @@
 const npm = require('./npm.js')
+const chromeWebStore = require('./chrome-web-store.js')
 
 module.exports = {
-  npm
+  npm,
+  'chrome-web-store': chromeWebStore,
 }

--- a/libs/live-fns/chrome-web-store.js
+++ b/libs/live-fns/chrome-web-store.js
@@ -1,8 +1,22 @@
-const chrome = require('chrome-webstore')
+const webstore = require('chrome-webstore')
 const millify = require('millify')
 
+const round = (value, decimals) =>
+  Number(Math.round(value + 'e' + decimals) + 'e-' + decimals)
+
+const stars = (average) => {
+  const base = Math.floor(average)
+  const fraction = average - base
+  return ((full = ''.padEnd(base, '★')) =>
+    // TODO: update when Unicode 11 goes mainstream
+    // between 0.33 and 0.66 should be `half star` symbol
+    fraction >= 0.33 && fraction <= 0.66 ? full.padEnd(base + 1, '★') :
+    fraction > 0.66 ? full.padEnd(base + 1, '★') : full
+  )().padEnd(5, '☆')
+}
+
 module.exports = async function (method, ...args) {
-  const meta = await chrome.extension({id: args[0]})
+  const meta = await webstore.detail({id: args[0]})
   switch (method) {
     case 'v':
       return {
@@ -13,32 +27,31 @@ module.exports = async function (method, ...args) {
     case 'users':
       return {
         subject: 'users',
-        status: millify(parseInt(meta.interactionCount.replace(',', ''))),
+        status: millify(parseInt(meta.users.replace(',', ''))),
         color: 'green'
       }
     case 'price':
       return {
         subject: 'price',
-        status: `$${meta.price}`,
+        status: meta.price,
         color: 'green'
       }
     case 'rating':
       return {
         subject: 'rating',
-        status: `${meta.ratingValue}/5`,
+        status: `${round(meta.rating.average, 2)}/5`,
         color: 'green'
       }
     case 'stars':
       return {
         subject: 'stars',
-        status: Array(Math.ceil(meta.ratingValue)).fill('★').concat(
-          Array(5 - Math.ceil(meta.ratingValue)).fill('☆')).join(''),
+        status: stars(meta.rating.average),
         color: 'green'
       }
     case 'rating-count':
       return {
         subject: 'rating count',
-        status: `${meta.ratingCount} total`,
+        status: `${meta.rating.count} total`,
         color: 'green'
       }
     default:

--- a/libs/live-fns/chrome-web-store.js
+++ b/libs/live-fns/chrome-web-store.js
@@ -1,0 +1,51 @@
+const chrome = require('chrome-webstore')
+const millify = require('millify')
+
+module.exports = async function (method, ...args) {
+  const meta = await chrome.extension({id: args[0]})
+  switch (method) {
+    case 'v':
+      return {
+        subject: 'chrome web store',
+        status: meta.version,
+        color: 'blue'
+      }
+    case 'users':
+      return {
+        subject: 'users',
+        status: millify(parseInt(meta.interactionCount.replace(',', ''))),
+        color: 'green'
+      }
+    case 'price':
+      return {
+        subject: 'price',
+        status: `$${meta.price}`,
+        color: 'green'
+      }
+    case 'rating':
+      return {
+        subject: 'rating',
+        status: `${meta.ratingValue}/5`,
+        color: 'green'
+      }
+    case 'stars':
+      return {
+        subject: 'stars',
+        status: Array(Math.ceil(meta.ratingValue)).fill('★').concat(
+          Array(5 - Math.ceil(meta.ratingValue)).fill('☆')).join(''),
+        color: 'green'
+      }
+    case 'rating-count':
+      return {
+        subject: 'rating count',
+        status: `${meta.ratingCount} total`,
+        color: 'green'
+      }
+    default:
+      return {
+        subject: 'chrome',
+        status: 'unknown',
+        color: 'grey'
+      }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -227,6 +227,15 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "chrome-webstore": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-webstore/-/chrome-webstore-0.0.4.tgz",
+      "integrity": "sha512-KF4mEXOMMBqEA3niWEh0u2fSK5IEcuJTp5MkkZhZU4CRcZ8QTgn0/GnjT8Iefg5+M9GFP3EBzXyP6HWd3rM4fg==",
+      "requires": {
+        "html-entities": "^1.2.1",
+        "request-compose": "0.0.18"
+      }
+    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
@@ -844,6 +853,11 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
       "integrity": "sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A==",
       "dev": true
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "iconv-lite": {
       "version": "0.4.23",
@@ -1491,6 +1505,11 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "request-compose": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/request-compose/-/request-compose-0.0.18.tgz",
+      "integrity": "sha512-WJA6FSmA8xISjZwdUxZylZJF+HHV6e/e43a+5FbI9SGz+3CycodLqINxtToUsQPDqukxsUV5H0pwfqq6MmkJDw=="
     },
     "require-uncached": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,12 +228,11 @@
       "dev": true
     },
     "chrome-webstore": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/chrome-webstore/-/chrome-webstore-0.0.4.tgz",
-      "integrity": "sha512-KF4mEXOMMBqEA3niWEh0u2fSK5IEcuJTp5MkkZhZU4CRcZ8QTgn0/GnjT8Iefg5+M9GFP3EBzXyP6HWd3rM4fg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chrome-webstore/-/chrome-webstore-1.0.0.tgz",
+      "integrity": "sha512-MdDccnTov5c5CseeNCYDovJmDoytfJb8rYgwAty01Lc2awjtk6XkBsA9EpoxI/bGSC9KkP5CiGPrnFtckBsYPQ==",
       "requires": {
-        "html-entities": "^1.2.1",
-        "request-compose": "0.0.18"
+        "request-compose": "0.0.19"
       }
     },
     "circular-json": {
@@ -853,11 +852,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
       "integrity": "sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A==",
       "dev": true
-    },
-    "html-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "iconv-lite": {
       "version": "0.4.23",
@@ -1507,9 +1501,9 @@
       }
     },
     "request-compose": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/request-compose/-/request-compose-0.0.18.tgz",
-      "integrity": "sha512-WJA6FSmA8xISjZwdUxZylZJF+HHV6e/e43a+5FbI9SGz+3CycodLqINxtToUsQPDqukxsUV5H0pwfqq6MmkJDw=="
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/request-compose/-/request-compose-0.0.19.tgz",
+      "integrity": "sha512-BBMilZ4uReMzOCXvysw6l8nT5WwQDo/H8vaYNQ4BXPa7/0OJIaJskk4Ozzfpd2bmLb5ZQLpxJf/FMCeTX5QrkQ=="
     },
     "require-uncached": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "badgen": "^1.1.3",
-    "chrome-webstore": "0.0.4",
+    "chrome-webstore": "^1.0.0",
     "find-my-way": "^1.15.1",
     "lru-cache": "^4.1.3",
     "millify": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "badgen": "^1.1.3",
+    "chrome-webstore": "0.0.4",
     "find-my-way": "^1.15.1",
     "lru-cache": "^4.1.3",
     "millify": "^2.0.1",


### PR DESCRIPTION
Regarding this https://github.com/amio/badgen-service/issues/2#issuecomment-404457713

![badgen](https://user-images.githubusercontent.com/1694112/42636698-1d02b104-85f2-11e8-98b4-3a652ade7528.png)

WIP, I'm pushing this mainly for feedback at this point.

- I want to bump `chrome-webstore` to version `1.0.0` before (eventually) merging, otherwise you won't receive any bugfixes using `^0.0.x`, after all it's a scraper so things can brake from time to time
- probably I'll change some of the meta keys before releasing version `1.0.0`
- the star rating currently uses `Math.ceil`, but in Chrome Web Store stars are rounded to 0.5, meaning: 3.5-4.0 = ★★★★☆, 4.0-4.5 = ★★★★☆ should be 4 and a half star, >4.5 = ★★★★★, no idea if there is a half full star symbol

Let me know what do you think!