### PR TITLE
Update chrome-web-store version badge

### DIFF
--- a/libs/live-fns/chrome-web-store.js
+++ b/libs/live-fns/chrome-web-store.js
@@ -22,8 +22,8 @@ module.exports = async function (method, ...args) {
     case 'v':
       return {
         subject: 'chrome web store',
-        status: meta.version,
-        color: 'blue'
+        status: 'v' + meta.version,
+        color: meta.version[0] === '0' ? 'orange' : 'blue'
       }
     case 'users':
       return {
@@ -57,7 +57,7 @@ module.exports = async function (method, ...args) {
       }
     default:
       return {
-        subject: 'chrome',
+        subject: 'chrome web store',
         status: 'unknown',
         color: 'grey'
       }

--- a/now.json
+++ b/now.json
@@ -2,7 +2,6 @@
   "alias": "badgen",
   "public": true,
   "files": [
-    "index.md",
     "service.js",
     "libs"
   ],


### PR DESCRIPTION
Two changes

- Add a 'v' to status text, make it clear a version number.
- Use 'orange' as status background for version under 1.0.

@simov What do you think?