### PR TITLE
Update travis badge, compat with .com & .org

### DIFF
--- a/libs/index.md
+++ b/libs/index.md
@@ -60,7 +60,7 @@ Available color names:
 | homebrew version | ![](/homebrew/v/fish) | [/homebrew/v/fish](/homebrew/v/fish)
 | homebrew version | ![](/homebrew/v/cake) | [/homebrew/v/cake](/homebrew/v/cake)
 | travis | ![](/travis/amio/micro-cors) | [/travis/amio/micro-cors](/travis/amio/micro-cors)
-| travis (org) | ![](/travis-org/styfle/packagephobia) | [/travis-org/styfle/packagephobia](/travis-org/styfle/packagephobia)
+| travis | ![](/travis/styfle/packagephobia) | [/travis/styfle/packagephobia](/travis/styfle/packagephobia)
 | circleci | ![](/circleci/github/amio/now-go) | [/circleci/github/amio/now-go](/circleci/github/amio/now-go)
 | appveyor | ![](/appveyor/github/gruntjs/grunt) | [/appveyor/github/gruntjs/grunt](/appveyor/github/gruntjs/grunt)
 

--- a/libs/live-fns/_index.js
+++ b/libs/live-fns/_index.js
@@ -2,5 +2,6 @@ module.exports = {
   'chrome-web-store': require('./chrome-web-store.js'),
   'crates': require('./crates.js'),
   'homebrew': require('./homebrew.js'),
-  'npm': require('./npm.js')
+  'npm': require('./npm.js'),
+  'travis': require('./travis.js')
 }

--- a/libs/live-fns/travis.js
+++ b/libs/live-fns/travis.js
@@ -1,0 +1,32 @@
+const axios = require('../axios.js')
+
+module.exports = async function (user, repo, branch = 'master') {
+  const com = `https://api.travis-ci.com/${user}/${repo}.svg?branch=${branch}`
+  const org = `https://api.travis-ci.org/${user}/${repo}.svg?branch=${branch}`
+  const results = await Promise.all([
+    axios.get(com).then(res => res.data).catch(e => e),
+    axios.get(org).then(res => res.data).catch(e => e)
+  ])
+
+  if (results[0].match('passing') || results[1].match('passing')) {
+    return {
+      subject: 'build',
+      status: 'passing',
+      color: 'green'
+    }
+  }
+
+  if (results[0].match('failed') || results[1].match('failed')) {
+    return {
+      subject: 'build',
+      status: 'failed',
+      color: 'red'
+    }
+  }
+
+  return {
+    subject: 'build',
+    status: 'unknown',
+    color: 'grey'
+  }
+}

--- a/libs/redirect-fns/_index.js
+++ b/libs/redirect-fns/_index.js
@@ -1,6 +1,6 @@
 module.exports = {
   'appveyor': require('./appveyor.js'),
   'circleci': require('./circleci.js'),
-  'travis': require('./travis.js'),
+  // 'travis': require('./travis.js'),
   'travis-org': require('./travis-org.js')
 }

--- a/libs/redirect-fns/travis-org.js
+++ b/libs/redirect-fns/travis-org.js
@@ -1,3 +1,4 @@
 module.exports = function (...args) {
+  console.log('travis-org', args.join('/'))
   return `https://api.travis-ci.org/${args.join('/')}.svg?branch=master`
 }

--- a/libs/redirect-fns/travis.js
+++ b/libs/redirect-fns/travis.js
@@ -1,3 +1,0 @@
-module.exports = function (...args) {
-  return `https://api.travis-ci.com/${args.join('/')}.svg?branch=master`
-}

--- a/now.json
+++ b/now.json
@@ -2,7 +2,6 @@
   "alias": "badgen",
   "public": true,
   "files": [
-    "index.md",
     "service.js",
     "libs"
   ],


### PR DESCRIPTION
@styfle I have an idea to fill the gap between travis-ci.com & travis-ci.org (#4), request both and choose the right one:

https://github.com/amio/badgen-service/blob/47ae7df3fefefd4c8e03fa7b74609a837b433714/libs/live-fns/travis.js#L4-L17