### PR TITLE
fix: add npm downloads total

### DIFF
--- a/libs/live-fns/npm.js
+++ b/libs/live-fns/npm.js
@@ -59,6 +59,8 @@ async function download (period, args) {
     const today = new Date()
 
     endpoint.push(`/range/2005-01-01:${today.getFullYear() + 1}-01-01`)
+  } else {
+    endpoint.push(`/point/${period}`)
   }
   endpoint.push(`/${args.join('/')}`)
 

--- a/libs/live-fns/npm.js
+++ b/libs/live-fns/npm.js
@@ -4,10 +4,12 @@ const millify = require('millify')
 // https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md
 // https://unpkg.com/
 
-module.exports = async function (method, ...args) {
+module.exports = async function npm (method, ...args) {
   switch (method) {
     case 'v':
       return version(args)
+    case 'dt':
+      return download('total', args)
     case 'dd':
       return download('last-day', args)
     case 'dw':
@@ -50,11 +52,28 @@ async function pkg (topic, args) {
 }
 
 async function download (period, args) {
-  const endpoint = `https://api.npmjs.org/downloads/point/${period}/${args.join('/')}`
-  const stats = await axios.get(endpoint).then(res => res.data)
+  const endpoint = ['https://api.npmjs.org/downloads']
+  const isTotal = period === 'total'
+
+  if (isTotal) {
+    const today = new Date()
+
+    endpoint.push(`/range/2005-01-01:${today.getFullYear() + 1}-01-01`)
+  }
+  endpoint.push(`/${args.join('/')}`)
+
+  const per = isTotal ? '' : period.replace('last-', '/')
+  const stats = await axios.get(endpoint.join('')).then(res => res.data)
+
+  if (isTotal) {
+    stats.downloads = stats.downloads.reduce((prev, { downloads }) => {
+      return prev + downloads
+    }, 0)
+  }
+
   return {
     subject: 'downloads',
-    status: millify(stats.downloads) + period.replace('last-', '/'),
+    status: millify(stats.downloads) + per,
     color: 'green'
   }
 }


### PR DESCRIPTION
resolves #13 

Huh. That was fast and fun! :tada:

That's a service, that's a library, hooorey!

Shields sucks, for years. I started such service with koa back in 2014 if i remember correctly. But never got the time to finish it "officially" and release it.

It was times that there was mostly ES5 and no Babel or such :D 
It was times, that Shields "server.js" was around 2000-3000 lines of code... 
and HELL they still add to that file?! Currently it is 7900+, wtf.