### PR TITLE
fix: add eslintConfig field, so IDEs are happy

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   },
   "devDependencies": {
     "standard": "^11.0.1"
-  }
+  },
+  "eslintConfig": {
+    "extends": "standard"
+  }  
 }


### PR DESCRIPTION
A lot better.

For devs like me that only have ESLint in their editor (VSCode), it's just enough.
Also, worth nothing, because both NPM and Yarn already support "flat deps".