### PR TITLE
fix(travis): more ensurance

### DIFF
--- a/libs/live-fns/travis.js
+++ b/libs/live-fns/travis.js
@@ -3,12 +3,12 @@ const axios = require('../axios.js')
 module.exports = async function (user, repo, branch = 'master') {
   const com = `https://api.travis-ci.com/${user}/${repo}.svg?branch=${branch}`
   const org = `https://api.travis-ci.org/${user}/${repo}.svg?branch=${branch}`
-  const results = await Promise.all([
-    axios.get(com).then(res => res.data).catch(e => e),
-    axios.get(org).then(res => res.data).catch(e => e)
+  const res = await Promise.all([
+    axios.get(com).then(({ data }) => data).catch(e => e),
+    axios.get(org).then(({ data }) => data).catch(e => e)
   ])
 
-  if (results[0].match('passing') || results[1].match('passing')) {
+  if (res[0].match(/passed|passing/) || res[1].match(/passed|passing/)) {
     return {
       subject: 'build',
       status: 'passing',
@@ -16,7 +16,7 @@ module.exports = async function (user, repo, branch = 'master') {
     }
   }
 
-  if (results[0].match('failed') || results[1].match('failed')) {
+  if (res[0].match(/failed|failing/) || res[1].match(/failed|failing/)) {
     return {
       subject: 'build',
       status: 'failed',


### PR DESCRIPTION
Why? Because while doing #19 i've just realized that for some reason failing builds are shown as `unknown`. That so, becuase it response contains `failing` not `failed`.

I'm not sure if it depends on the different API endpoints, so.. for more safety lelts just make it regex.