### PR TITLE
New index page

### DIFF
--- a/libs/index.md
+++ b/libs/index.md
@@ -27,12 +27,32 @@ Available color names:
 ![](/badge/color/purple/purple)
 ![](/badge/color/grey/grey)
 
+Available query params:
+
+| param | desc |
+| ----- | ---- |
+|`label`| Override default subject text ([URL-Encoding][url-enc-href] needed for spaces or special characters).
+|`style`| Force flat style with `style=flat`. [e.g.][style-eg-href]
+|`emoji`| Set `emoji=1` if subject/status text contains emoji.
+| `list`| Set `list=1` will replace `,` with ` \| ` in status text. [e.g.][list-eg-href]
+| `icon`| Use builtin icon in front of label. [e.g.][icon-eg-href]
+
+Available icons:
+
+![](/badge/icon/travis?icon=travis)
+![](/badge/icon/appveyor?icon=appveyor)
+![](/badge/icon/circleci?icon=circleci)
+![](/badge/icon/github?icon=github)
+![](/badge/icon/docker?icon=docker)
+![](/badge/icon/mozillafirefox?icon=mozillafirefox)
+![](/badge/icon/googlechrome?icon=googlechrome)
+
 ## Examples
 
 #### Static Badge
 
 | Preview | URL |
-| --- | --- |
+| ------- | --- |
 |![](/badge/chat/gitter/purple) | [/badge/chat/gitter/purple](/badge/chat/gitter/purple)
 |![](/badge/style/standard/f2a) | [/badge/style/standard/f2a](/badge/style/standard/f2a)
 |![](/badge/stars/★★★★☆) | [/badge/stars/★★★★☆](/badge/stars/★★★★☆)
@@ -42,64 +62,20 @@ Available color names:
 
 #### Live Badge
 
-| Keyword | Preview | URL |
-| --- | --- | --- |
-| github release | ![](/github/release/babel/babel) | [/github/release/babel/babel](/github/release/babel/babel)
-| github tag | ![](/github/tag/micromatch/micromatch) | [/github/tag/micromatch/micromatch](/github/tag/micromatch/micromatch)
-| npm version | ![](/npm/v/express) | [/npm/v/express](/npm/v/express)
-| npm version | ![](/npm/v/marked) | [/npm/v/marked](/npm/v/marked)
-| npm version (scoped) | ![](/npm/v/@nestjs/core) | [/npm/v/@nestjs/core](/npm/v/@nestjs/core)
-| npm downloads/week | ![](/npm/dw/express) | [/npm/dw/express](/npm/dw/express)
-| npm downloads/month | ![](/npm/dm/express) | [/npm/dm/express](/npm/dm/express)
-| npm downloads/year | ![](/npm/dy/express) | [/npm/dy/express](/npm/dy/express)
-| npm downloads/total | ![](/npm/dt/micromatch) | [/npm/dt/express](/npm/dt/micromatch)
-| npm license | ![](/npm/license/lodash) | [/npm/license/lodash](/npm/license/lodash)
-| npm engines (node)  | ![](/npm/node/express) | [/npm/node/express](/npm/node/express)
-| crates.io version | ![](/crates/v/regex) | [/crates/v/regex](/crates/v/regex)
-| crates.io downloads | ![](/crates/d/regex) | [/crates/d/regex](/crates/d/regex)
-| crates.io downloads/latest | ![](/crates/dl/regex) | [/crates/dl/regex](/crates/dl/regex)
-| chrome extension version | ![](/chrome-web-store/v/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | [/chrome-web-store/v/ckkdlimhmcjmikdlpkmbgfkaikojcbjk](/chrome-web-store/v/ckkdlimhmcjmikdlpkmbgfkaikojcbjk)
-| chrome extension users | ![](/chrome-web-store/users/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | [/chrome-web-store/users/ckkdlimhmcjmikdlpkmbgfkaikojcbjk](/chrome-web-store/users/ckkdlimhmcjmikdlpkmbgfkaikojcbjk)
-| chrome extension price | ![](/chrome-web-store/price/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | [/chrome-web-store/price/ckkdlimhmcjmikdlpkmbgfkaikojcbjk](/chrome-web-store/price/ckkdlimhmcjmikdlpkmbgfkaikojcbjk)
-| chrome extension rating | ![](/chrome-web-store/rating/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | [/chrome-web-store/rating/ckkdlimhmcjmikdlpkmbgfkaikojcbjk](/chrome-web-store/rating/ckkdlimhmcjmikdlpkmbgfkaikojcbjk)
-| chrome extension stars | ![](/chrome-web-store/stars/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | [/chrome-web-store/stars/ckkdlimhmcjmikdlpkmbgfkaikojcbjk](/chrome-web-store/stars/ckkdlimhmcjmikdlpkmbgfkaikojcbjk)
-| chrome extension rating count | ![](/chrome-web-store/rating-count/ckkdlimhmcjmikdlpkmbgfkaikojcbjk) | [/chrome-web-store/rating-count/ckkdlimhmcjmikdlpkmbgfkaikojcbjk](/chrome-web-store/rating-count/ckkdlimhmcjmikdlpkmbgfkaikojcbjk)
-| mozilla add-on version | ![](/amo/v/markdown-viewer-chrome) | [/amo/v/markdown-viewer-chrome](/amo/v/markdown-viewer-chrome)
-| mozilla add-on users | ![](/amo/users/markdown-viewer-chrome) | [/amo/users/markdown-viewer-chrome](/amo/users/markdown-viewer-chrome)
-| mozilla add-on rating | ![](/amo/rating/markdown-viewer-chrome) | [/amo/rating/markdown-viewer-chrome](/amo/rating/markdown-viewer-chrome)
-| mozilla add-on stars | ![](/amo/stars/markdown-viewer-chrome) | [/amo/stars/markdown-viewer-chrome](/amo/stars/markdown-viewer-chrome)
-| mozilla add-on reviews | ![](/amo/reviews/markdown-viewer-chrome) | [/amo/reviews/markdown-viewer-chrome](/amo/reviews/markdown-viewer-chrome)
-| homebrew version | ![](/homebrew/v/fish) | [/homebrew/v/fish](/homebrew/v/fish)
-| homebrew version | ![](/homebrew/v/cake) | [/homebrew/v/cake](/homebrew/v/cake)
-| travis | ![](/travis/amio/micro-cors) | [/travis/amio/micro-cors](/travis/amio/micro-cors)
-| travis (branch) | ![](/travis/babel/babel/6.x) | [/travis/babel/babel/6.x](/travis/babel/babel/6.x)
-| codecov | ![](/codecov/c/github/tunnckoCore/gitcommit) | [/codecov/c/github/tunnckoCore/gitcommit](/codecov/c/github/tunnckoCore/gitcommit)
-| codecov (branch) | ![](/codecov/c/github/babel/babel/6.x) | [/codecov/c/github/babel/babel/6.x](/codecov/c/github/babel/babel/6.x)
-| circleci | ![](/circleci/github/amio/now-go) | [/circleci/github/amio/now-go](/circleci/github/amio/now-go)
-| circleci (branch) | ![](/circleci/github/amio/now-go/master) | [/circleci/github/amio/now-go/master](/circleci/github/amio/now-go/master)
-| appveyor ci | ![](/appveyor/ci/gruntjs/grunt) | [/appveyor/ci/gruntjs/grunt](/appveyor/ci/gruntjs/grunt)
-| david-dm | ![](/david/dep/zeit/pkg) | [/david/dep/zeit/pkg](/david/dep/zeit/pkg)
-| david-dm dev dependencies | ![](/david/dev/zeit/pkg) | [/david/dev/zeit/pkg](/david/dev/zeit/pkg)
-| david-dm peer dependencies | ![](/david/peer/epoberezkin/ajv-keywords) | [/david/peer/epoberezkin/ajv-keywords](/david/peer/epoberezkin/ajv-keywords)
-| david-dm optional dependencies | ![](/david/optional/epoberezkin/ajv-keywords) | [/david/optional/epoberezkin/ajv-keywords](/david/optional/epoberezkin/ajv-keywords)
-| docker pulls (library) | ![](/docker/pulls/library/ubuntu) | [/docker/pulls/library/ubuntu](/docker/pulls/library/ubuntu)
-| docker stars (library) | ![](/docker/stars/library/ubuntu) | [/docker/stars/library/ubuntu](/docker/stars/library/ubuntu)
-| docker pulls (scoped) | ![](/docker/pulls/amio/node-chrome) | [/docker/pulls/amio/node-chrome](/docker/pulls/amio/node-chrome)
-| docker stars (icon & label) | ![](/docker/stars/library/mongo?icon=docker&label=stars) | [/docker/stars/library/mongo?icon=docker&label=stars](/docker/stars/library/mongo?icon=docker&label=stars)
-| packagephobia publish size | ![](/packagephobia/publish/webpack) | [/packagephobia/publish/webpack](/packagephobia/publish/webpack)
-| packagephobia install size | ![](/packagephobia/install/webpack) | [/packagephobia/install/webpack](/packagephobia/install/webpack)
-| uptime robot status | ![](/uptime-robot/status/m780731617-a9e038618dc1aee36a44c4af) | [/uptime-robot/status/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/status/m780731617-a9e038618dc1aee36a44c4af)
-| uptime robot uptime (day) | ![](/uptime-robot/day/m780731617-a9e038618dc1aee36a44c4af) | [/uptime-robot/lasy-day/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/day/m780731617-a9e038618dc1aee36a44c4af)
-| uptime robot uptime (week) | ![](/uptime-robot/week/m780731617-a9e038618dc1aee36a44c4af) | [/uptime-robot/lasy-week/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/week/m780731617-a9e038618dc1aee36a44c4af)
-| uptime robot uptime (month) | ![](/uptime-robot/month/m780731617-a9e038618dc1aee36a44c4af) | [/uptime-robot/lasy-month/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/month/m780731617-a9e038618dc1aee36a44c4af)
-| uptime robot response (last hour) | ![](/uptime-robot/response/m780731617-a9e038618dc1aee36a44c4af) | [/uptime-robot/response/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/response/m780731617-a9e038618dc1aee36a44c4af)
+<div id="live-badge-examples"></div>
 
-## Query params
-
-- `label`: Override default subject text ([URL-Encoding][url-enc-href] needed for spaces or special characters).
-- `emoji`: Use `emoji=1` if subject/status text contains emoji.
-- `style`: Force flat style with `style=flat`. [e.g.][style-eg-href]
-- `list`: `list=1` will replace `,` with ` | ` in status text. [e.g.][list-eg-href]
+<script>
+  window.liveBadges = {
+    github: [
+      ['release', '/github/release/babel/babel'],
+      ['tag', '/github/tag/micromatch/micromatch'],
+    ],
+    packagephobia: [
+      ['publish size', '/packagephobia/publish/webpack'],
+      ['install size', '/packagephobia/install/webpack']
+    ]
+  }
+</script>
 
 ## About
 
@@ -109,6 +85,41 @@ Made with ❤️ by [Amio](https://github.com/amio)
   <a href="https://twitter.com/badgen_net">Twitter</a>
 </span>
 
+<script>
+  if (window.location.hostname === 'flat.badgen.net') {
+    const code = document.querySelector('pre code')
+    code.innerText = code.innerText.replace(
+      'badgen.net',
+      'flat.badgen.net'
+    ).replace(/\\n/g, '\\n     ')
+  }
+</script>
+
+<script type="module">
+  import { html, render } from 'https://cdn.jsdelivr.net/npm/lit-html@0.10.2/lit-html.js'
+
+  const genExamples = (badges) => html`
+    <div>${Object.entries(badges).map(([service, examples]) => html`
+      <dl>
+        <dt>${service}</dt>
+        ${examples.map(([desc, src]) => html`
+          <dd>
+            <b>${desc}</b>
+            <i><img src=${src} /></i>
+            <span><a href=${src}>${src}</a></span>
+          </dd>
+        `)}
+      </dl>
+    `)}</div>
+  `
+
+  render(
+    genExamples(window.liveBadges),
+    document.querySelector('#live-badge-examples')
+  )
+</script>
+
 [url-enc-href]: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding
-[list-eg-href]: /badge/platform/ios,macos,tvos?list=1
 [style-eg-href]: /badge/color/blue/blue?style=flat
+[list-eg-href]: /badge/platform/ios,macos,tvos?list=1
+[icon-eg-href]: /badge/docker/v1.2.3/blue?icon=docker

--- a/libs/index.md
+++ b/libs/index.md
@@ -163,6 +163,7 @@ Made with ❤️ by [Amio](https://github.com/amio)
 </span>
 
 <script>
+  // Update usage url for 'flat.badgen.net'
   if (window.location.hostname === 'flat.badgen.net') {
     const code = document.querySelector('pre code')
     code.innerText = code.innerText.replace(
@@ -173,12 +174,13 @@ Made with ❤️ by [Amio](https://github.com/amio)
 </script>
 
 <script type="module">
+  // Render live badge examples
   import { html, render } from 'https://cdn.jsdelivr.net/npm/lit-html@0.10.2/lit-html.js'
 
   const genExamples = (badges) => html`
     <div>${Object.entries(badges).map(([service, examples]) => html`
       <dl>
-        <dt>${service}</dt>
+        <dt id="${service}"><a href="#${service}">${service}</a></dt>
         ${examples.map(([desc, src]) => html`
           <dd>
             <b>${desc}</b>

--- a/libs/index.md
+++ b/libs/index.md
@@ -66,13 +66,90 @@ Available icons:
 
 <script>
   window.liveBadges = {
+    /* source control */
     github: [
+      // [ <desc>, <badge-image-src> ]
       ['release', '/github/release/babel/babel'],
       ['tag', '/github/tag/micromatch/micromatch'],
     ],
+    /* release registries */
+    npm: [
+      ['version', '/npm/v/express'],
+      ['version', '/npm/v/marked'],
+      ['version (scoped)', '/npm/v/@nestjs/core'],
+      ['weekly downloads', '/npm/dw/express'],
+      ['monthly downloads', '/npm/dm/express'],
+      ['yearly downloads', '/npm/dy/express'],
+      ['total downloads', '/npm/dt/express'],
+      ['license', '/npm/license/lodash'],
+      ['engines (node)', '/npm/node/express']
+    ],
+    crates: [
+      ['version', '/crates/v/regex'],
+      ['downloads', '/crates/d/regex'],
+      ['downloads (latest)', '/crates/dl/regex']
+    ],
+    docker: [
+      ['pulls (library)', '/docker/pulls/library/ubuntu'],
+      ['stars (library)', '/docker/stars/library/ubuntu'],
+      ['pulls (scoped)', '/docker/pulls/amio/node-chrome'],
+      ['stars (icon & label)', '/docker/stars/library/mongo?icon=docker&label=stars']
+    ],
+    homebrew: [
+      ['version', '/homebrew/v/fish'],
+      ['version', '/homebrew/v/cake']
+    ],
+    'chrome extension': [
+      ['version', '/chrome-web-store/v/ckkdlimhmcjmikdlpkmbgfkaikojcbjk'],
+      ['users', '/chrome-web-store/users/ckkdlimhmcjmikdlpkmbgfkaikojcbjk'],
+      ['price', '/chrome-web-store/price/ckkdlimhmcjmikdlpkmbgfkaikojcbjk'],
+      ['rating', '/chrome-web-store/rating/ckkdlimhmcjmikdlpkmbgfkaikojcbjk'],
+      ['stars', '/chrome-web-store/stars/ckkdlimhmcjmikdlpkmbgfkaikojcbjk'],
+      ['rating count', '/chrome-web-store/rating-count/ckkdlimhmcjmikdlpkmbgfkaikojcbjk']
+    ],
+    'mozilla add-on': [
+      ['version', '/amo/v/markdown-viewer-chrome'],
+      ['users', '/amo/users/markdown-viewer-chrome'],
+      ['rating', '/amo/rating/markdown-viewer-chrome'],
+      ['stars', '/amo/stars/markdown-viewer-chrome'],
+      ['reviews', '/amo/reviews/markdown-viewer-chrome']
+    ],
+    /* CIs */
+    travis: [
+      ['build', '/travis/amio/micro-cors'],
+      ['build (branch)', '/travis/babel/babel/6.x'],
+      // ['build (icon)', '/travis/babel/babel?icon=travis'],
+    ],
+    circleci: [
+      ['build', '/circleci/github/amio/now-go'],
+      ['build (branch)', '/circleci/github/amio/now-go/master'],
+      // ['build (icon)', '/circleci/github/amio/now-go?icon=circleci'],
+    ],
+    appveyor: [
+      ['build', '/appveyor/ci/gruntjs/grunt'],
+      // ['build (icon)', '/appveyor/ci/gruntjs/grunt?icon=appveyor']
+    ],
+    codecov: [
+      ['coverage', '/codecov/c/github/tunnckoCore/gitcommit'],
+      ['coverage (branch)', '/codecov/c/github/babel/babel/6.x']
+    ],
+    'david-dm': [
+      ['dependencies', '/david/dep/zeit/pkg'],
+      ['dev dependencies', '/david/dev/zeit/pkg'],
+      ['peer dependencies', '/david/peer/epoberezkin/ajv-keywords'],
+      ['optional dependencies', '/david/optional/epoberezkin/ajv-keywords'],
+    ],
+    /* quality & metrics */
     packagephobia: [
       ['publish size', '/packagephobia/publish/webpack'],
       ['install size', '/packagephobia/install/webpack']
+    ],
+    'uptime robot': [
+      ['status', '/uptime-robot/status/m780731617-a9e038618dc1aee36a44c4af'],
+      ['(24 hours) uptime', '/uptime-robot/day/m780731617-a9e038618dc1aee36a44c4af'],
+      ['(past week) uptime', '/uptime-robot/week/m780731617-a9e038618dc1aee36a44c4af'],
+      ['(past month) uptime', '/uptime-robot/month/m780731617-a9e038618dc1aee36a44c4af'],
+      ['(last hours) response', '/uptime-robot/response/m780731617-a9e038618dc1aee36a44c4af']
     ]
   }
 </script>

--- a/libs/serve-index.js
+++ b/libs/serve-index.js
@@ -4,7 +4,7 @@ module.exports = serveMarked('libs/index.md', {
   title: 'Badgen - Fast badge generating service',
   preset: 'merri',
   inlineCSS: `
-    body { max-width: 960px; padding: 0 1.6em 1em }
+    body { max-width: 950px; padding: 0 1.6em 1em }
     h1 + p { letter-spacing: 0.1px }
     h1 + p a { display: inline-block; margin-top: 1em; padding: 4px; height: 20px }
     h1 + p img { height: 20px }
@@ -21,7 +21,8 @@ module.exports = serveMarked('libs/index.md', {
     dt { margin-bottom: 1em; padding-top: 1em; border-bottom: 1px solid #DDD; line-height: 2em }
     dt a { color: #333; position: relative }
     dt a:hover { text-decoration: none }
-    dt a:hover:before { content: '➻'; position: absolute; left: -1.2em; line-height: 1.7em; font-size: 128%; color: #CCC }
+    dt a:hover:before { content: '➻'; display: inline-block; width: 0px; position: relative }
+    dt a:hover:before { left: -1.2em; font: 20px/20px Arial; vertical-align: middle; color: #CCC }
     dd { font: 14px/20px monospace; vertical-align: top; height: 28px; white-space: nowrap; margin: 0 }
     dd img { vertical-align: top }
     dd b { display: inline-block; min-width: 14em; text-align: right; font-weight: 300 }

--- a/libs/serve-index.js
+++ b/libs/serve-index.js
@@ -5,28 +5,24 @@ module.exports = serveMarked('libs/index.md', {
   preset: 'merri',
   inlineCSS: `
     body { max-width: 890px; padding-bottom: 1em }
-    table { border-spacing: 0 }
-    td { padding: 0 1em 0 0; font-size: 14px; white-space: nowrap; height: 26px }
-    td img { height: 20px; position: relative; top: 2px }
-    td a { font: 12px/14px monospace }
-    pre, code { background-color: #f4f6f9; font-weight: 400 }
-    li code { padding: 0.2em 0.4em; display: pre }
-    li { padding: 0.4em 0 }
     h1 + p { letter-spacing: 0.1px }
     h1 + p a { display: inline-block; margin-top: 1em; padding: 4px; height: 20px }
     h1 + p img { height: 20px }
+
+    table { border-spacing: 0; vertical-align: top }
+    td { padding-right: 0.6em; height: 28px; font-size: 14px; white-space: nowrap }
+    td img { position: relative; top: 2px }
+    td a { font: 12px/20px monospace }
+    pre, code { background-color: #f2f5f9; font-weight: 400 }
+    pre > code { padding: 0 }
+    table code { padding: 0.3em 0.5em; display: pre }
+
+    dt { margin: 1em 0; border-bottom: 1px solid #DDD; line-height: 2em }
+    dd { font: 14px/20px monospace; vertical-align: top; height: 28px; white-space: nowrap }
+    dd img { vertical-align: top }
+    dd b { display: inline-block; min-width: 12em; text-align: right; font-weight: 300 }
+    dd i { display: inline-block; min-width: 12em }
   `,
   beforeHeadEnd: `<link rel="icon" type="image/svg+xml" href="/favicon.svg">`,
-  beforeBodyEnd: `
-    <script>
-      if (window.location.hostname === 'flat.badgen.net') {
-        const code = document.querySelector('pre code')
-        code.innerText = code.innerText.replace(
-          'badgen.net',
-          'flat.badgen.net'
-        ).replace(/\\n/g, '\\n     ')
-      }
-    </script>
-  `,
   trackingGA: 'UA-4646421-14'
 })

--- a/libs/serve-index.js
+++ b/libs/serve-index.js
@@ -4,7 +4,7 @@ module.exports = serveMarked('libs/index.md', {
   title: 'Badgen - Fast badge generating service',
   preset: 'merri',
   inlineCSS: `
-    body { max-width: 890px; padding-bottom: 1em }
+    body { max-width: 920px; padding-bottom: 1em }
     h1 + p { letter-spacing: 0.1px }
     h1 + p a { display: inline-block; margin-top: 1em; padding: 4px; height: 20px }
     h1 + p img { height: 20px }
@@ -12,16 +12,16 @@ module.exports = serveMarked('libs/index.md', {
     table { border-spacing: 0; vertical-align: top }
     td { padding-right: 0.6em; height: 28px; font-size: 14px; white-space: nowrap }
     td img { position: relative; top: 2px }
-    td a { font: 12px/20px monospace }
+    td a { font: 14px/20px monospace }
     pre, code { background-color: #f2f5f9; font-weight: 400 }
     pre > code { padding: 0 }
     table code { padding: 0.3em 0.5em; display: pre }
 
     dt { margin: 1em 0; border-bottom: 1px solid #DDD; line-height: 2em }
-    dd { font: 14px/20px monospace; vertical-align: top; height: 28px; white-space: nowrap }
+    dd { font: 14px/20px monospace; vertical-align: top; height: 28px; white-space: nowrap; margin: 0 }
     dd img { vertical-align: top }
-    dd b { display: inline-block; min-width: 12em; text-align: right; font-weight: 300 }
-    dd i { display: inline-block; min-width: 12em }
+    dd b { display: inline-block; min-width: 14em; text-align: right; font-weight: 300 }
+    dd i { display: inline-block; min-width: 13em }
   `,
   beforeHeadEnd: `<link rel="icon" type="image/svg+xml" href="/favicon.svg">`,
   trackingGA: 'UA-4646421-14'

--- a/libs/serve-index.js
+++ b/libs/serve-index.js
@@ -4,7 +4,7 @@ module.exports = serveMarked('libs/index.md', {
   title: 'Badgen - Fast badge generating service',
   preset: 'merri',
   inlineCSS: `
-    body { max-width: 920px; padding-bottom: 1em }
+    body { max-width: 960px; padding: 0 1.6em 1em }
     h1 + p { letter-spacing: 0.1px }
     h1 + p a { display: inline-block; margin-top: 1em; padding: 4px; height: 20px }
     h1 + p img { height: 20px }
@@ -17,7 +17,11 @@ module.exports = serveMarked('libs/index.md', {
     pre > code { padding: 0 }
     table code { padding: 0.3em 0.5em; display: pre }
 
-    dt { margin: 1em 0; border-bottom: 1px solid #DDD; line-height: 2em }
+    dl { margin-top: 0 }
+    dt { margin-bottom: 1em; padding-top: 1em; border-bottom: 1px solid #DDD; line-height: 2em }
+    dt a { color: #333; position: relative }
+    dt a:hover { text-decoration: none }
+    dt a:hover:before { content: '➻'; position: absolute; left: -1.2em; line-height: 1.7em; font-size: 128%; color: #CCC }
     dd { font: 14px/20px monospace; vertical-align: top; height: 28px; white-space: nowrap; margin: 0 }
     dd img { vertical-align: top }
     dd b { display: inline-block; min-width: 14em; text-align: right; font-weight: 300 }


### PR DESCRIPTION
That [index.md](https://github.com/amio/badgen-service/blob/dca83facc83927e7ad6f4cd7678d6db53562bab6/libs/index.md) is horrible for editing 🙀

This PR create a new index page:

- Use `lit-html` to generate examples section.
- Move "Available query params" to first screen.
- Add "Available icons" section.

Preview at https://badgen-new-index.now.sh

### TODO

- [x] Complete live badge example list.
- [ ] Link to live badge's own doc page (e.g. [/docs/packagephobia](https://badgen.net/docs/packagephobia))