### PR TITLE
Allow specifying an empty label

### DIFF
--- a/libs/serve-badge.js
+++ b/libs/serve-badge.js
@@ -10,7 +10,7 @@ module.exports = function serveBadge (req, res, options = {}) {
   const { style, label, emoji, list, icon } = req.query
 
   const badgenParams = {
-    subject: String(label || subject),
+    subject: typeof label !== 'undefined' ? label : subject,
     status: String(list ? status.replace(/,/g, ' | ') : status),
     color: color,
     style: style || hostStyle,


### PR DESCRIPTION
This allows things like this:

![](https://badgen.net/circleci/github/amio/now-go?icon=circleci&label=) `/circleci/github/amio/now-go?icon=circleci&label=`

to look like this:


<img width="78" alt="screen shot 2018-07-28 at 3 42 34 pm" src="https://user-images.githubusercontent.com/166147/43357107-df5f6468-927c-11e8-898b-7d0f23468106.png">

If this is something you’re willing to support. :)