### PR TITLE
Add documentation links

### DIFF
--- a/libs/index.md
+++ b/libs/index.md
@@ -198,8 +198,9 @@ Available query params:
       ['yearly income', '/opencollective/yearly/webpack'],
     ]
   }
-  window.docPages = {
-    packagephobia: 'packagephobia',
+
+  window.links = {
+    packagephobia: { doc: true },
   }
 </script>
 
@@ -218,12 +219,13 @@ Available query params:
   // Render live badge examples
   import { html, render } from 'https://cdn.jsdelivr.net/npm/lit-html@0.10.2/lit-html.js'
 
-  const genExamples = (badges, docs) => html`
+  const genExamples = (badges, links) => html`
     <h4 id="live-badge">Live Badge</h4>
     <div>${Object.entries(badges).map(([service, examples]) => html`
       <dl>
         <dt id="${service}"><a href="#${service}">${service}</a>
-        ${docs[service] ? html`<a href="docs/${docs[service]}" target="_blank">Docs</a>` : ''}
+        ${links[service] && links[service].doc ?
+          html`<a href="docs/${service.replace(/ /m, '-')}" target="_blank">&nbsp;?</a>` : ''}
         </dt>
         ${examples.map(([desc, src]) => html`
           <dd>
@@ -241,7 +243,7 @@ Available query params:
   const badges = only ? { [only]: window.liveBadges[only] } : window.liveBadges
 
   render(
-    genExamples(badges, window.docPages),
+    genExamples(badges, window.links),
     document.querySelector('#live-badge-examples')
   )
 </script>

--- a/libs/index.md
+++ b/libs/index.md
@@ -198,6 +198,9 @@ Available query params:
       ['yearly income', '/opencollective/yearly/webpack'],
     ]
   }
+  window.docPages = {
+    packagephobia: 'packagephobia',
+  }
 </script>
 
 <script>
@@ -215,11 +218,13 @@ Available query params:
   // Render live badge examples
   import { html, render } from 'https://cdn.jsdelivr.net/npm/lit-html@0.10.2/lit-html.js'
 
-  const genExamples = (badges) => html`
+  const genExamples = (badges, docs) => html`
     <h4 id="live-badge">Live Badge</h4>
     <div>${Object.entries(badges).map(([service, examples]) => html`
       <dl>
-        <dt id="${service}"><a href="#${service}">${service}</a></dt>
+        <dt id="${service}"><a href="#${service}">${service}</a>
+        ${docs[service] ? html`<a href="docs/${docs[service]}" target="_blank">Docs</a>` : ''}
+        </dt>
         ${examples.map(([desc, src]) => html`
           <dd>
             <b>${desc}</b>
@@ -236,7 +241,7 @@ Available query params:
   const badges = only ? { [only]: window.liveBadges[only] } : window.liveBadges
 
   render(
-    genExamples(badges),
+    genExamples(badges, window.docPages),
     document.querySelector('#live-badge-examples')
   )
 </script>

--- a/libs/serve-index.js
+++ b/libs/serve-index.js
@@ -24,6 +24,7 @@ module.exports = serveMarked('libs/index.md', {
     dt a:hover { text-decoration: none }
     dt a:hover:before { content: '➻'; display: inline-block; width: 0px; position: relative }
     dt a:hover:before { left: -1.2em; font: 20px/20px Arial; vertical-align: middle; color: #CCC }
+    dt a:nth-child(2) { float: right }
     dd { font: 14px/20px monospace; vertical-align: top; height: 28px; white-space: nowrap; margin: 0 }
     dd img { vertical-align: top }
     dd b { font-family: Roboto,-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif }

--- a/libs/serve-index.js
+++ b/libs/serve-index.js
@@ -22,9 +22,10 @@ module.exports = serveMarked('libs/index.md', {
     dt { margin-bottom: 1em; padding-top: 1em; border-bottom: 1px solid #DDD; line-height: 2em }
     dt a { color: #333; position: relative }
     dt a:hover { text-decoration: none }
-    dt a:hover:before { content: '➻'; display: inline-block; width: 0px; position: relative }
-    dt a:hover:before { left: -1.2em; font: 20px/20px Arial; vertical-align: middle; color: #CCC }
-    dt a:nth-child(2) { float: right }
+    dt a:first-child:hover:before { content: '➻'; display: inline-block; width: 0px; position: relative }
+    dt a:first-child:hover:before { left: -1.2em; font: 20px/20px Arial; vertical-align: middle; color: #CCC }
+    dt a:nth-child(2) { background: #BBB; color: #FFF; font: 14px/16px sans-serif; height: 16px; width: 16px }
+    dt a:nth-child(2) { border-radius: 50%; display: inline-block; margin-left: 1em }
     dd { font: 14px/20px monospace; vertical-align: top; height: 28px; white-space: nowrap; margin: 0 }
     dd img { vertical-align: top }
     dd b { font-family: Roboto,-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif }


### PR DESCRIPTION
I've added links to the documentation in the examples page

![image](https://user-images.githubusercontent.com/17952318/43676748-5bbc8016-97f7-11e8-8382-fbc375df1d1f.png)

Don't hesitate to tell me if you would have designed them differently