### PR TITLE
Add uptime-robot documentation

### DIFF
--- a/libs/docs/uptime-robot.md
+++ b/libs/docs/uptime-robot.md
@@ -1,0 +1,34 @@
+# /uptime-robot
+![](/badge/badgen/uptime-robot)
+
+## Usage
+
+- `/uptime-robot/status/:api-key`   _status_
+- `/uptime-robot/day/:api-key`      _(24 hours) uptime_
+- `/uptime-robot/week/:api-key`     _(past week) uptime_
+- `/uptime-robot/month/:api-key`    _(past month) uptime_
+- `/uptime-robot/response/:api-key` _(last hours) response_
+
+## Creating the API key
+
+To use an `/uptime-robot` badge, you have to create or find an API key specific to your monitor
+<br/><br/>
+From your UptimeRobot dashboard, go to
+[My Settings](https://uptimerobot.com/dashboard.php#mySettings) > API Settings > Monitor-Specific API Keys
+
+## Examples
+
+![/uptime-robot/status/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/status/m780731617-a9e038618dc1aee36a44c4af)
+[/uptime-robot/status/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/status/m780731617-a9e038618dc1aee36a44c4af)
+
+![/uptime-robot/day/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/day/m780731617-a9e038618dc1aee36a44c4af)
+[/uptime-robot/day/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/day/m780731617-a9e038618dc1aee36a44c4af)
+
+![/uptime-robot/week/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/week/m780731617-a9e038618dc1aee36a44c4af)
+[/uptime-robot/week/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/week/m780731617-a9e038618dc1aee36a44c4af)
+
+![/uptime-robot/month/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/month/m780731617-a9e038618dc1aee36a44c4af)
+[/uptime-robot/month/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/month/m780731617-a9e038618dc1aee36a44c4af)
+
+![/uptime-robot/response/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/response/m780731617-a9e038618dc1aee36a44c4af)
+[/uptime-robot/response/m780731617-a9e038618dc1aee36a44c4af](/uptime-robot/response/m780731617-a9e038618dc1aee36a44c4af)

--- a/libs/index.md
+++ b/libs/index.md
@@ -218,6 +218,7 @@ Available query params:
 
   window.links = {
     packagephobia: { doc: true },
+    'uptime robot': { doc: true },
   }
 </script>
 


### PR DESCRIPTION
As discussed in issue #70, uptime-robot needs  a little documentation about where to find the API key