### PR TITLE
fix(live-fns/packagist): version detection

### DIFF
--- a/libs/live-fns/packagist.js
+++ b/libs/live-fns/packagist.js
@@ -1,32 +1,33 @@
 const millify = require('millify')
 
 const axios = require('../axios.js')
+const compareVersions = require('../utils/compare-versions.js')
 const semColor = require('../utils/sem-color.js')
 
-const pre = versions => versions.filter(v => v.includes('-'))
+const pre = versions => versions.filter(v => v.includes('-') && v.indexOf('dev') !== 0)
 const stable = versions => versions.filter(v => !v.includes('-'))
 const latest = versions => versions.length > 0 && versions.slice(-1)[0]
-const nodev = versions => versions.filter(version => version !== 'dev-master')
+const nodev = versions => versions.filter(v => v.indexOf('dev') === -1)
 
 module.exports = async function (topic, vendor, pkg, channel = 'stable') {
   const endpoint = `https://packagist.org/packages/${vendor}/${pkg}.json`
-  const response = await axios.get(endpoint).then(res => res.data)
+  const { package: packageMeta } = await axios.get(endpoint).then(res => res.data)
 
   switch (topic) {
     case 'v':
-      const versions = Object.keys(response.package.versions)
+      const versions = Object.keys(packageMeta.versions).sort(compareVersions)
 
       let version = ''
 
       switch (channel) {
         case 'latest':
-          version = latest(nodev(versions).reverse())
+          version = latest(nodev(versions))
           break
         case 'pre':
           version = latest(pre(versions))
           break
         default:
-          version = latest(stable(versions).reverse())
+          version = latest(stable(versions))
       }
 
       version = version || latest(versions)
@@ -39,73 +40,73 @@ module.exports = async function (topic, vendor, pkg, channel = 'stable') {
     case 'dt':
       return {
         subject: 'downloads',
-        status: millify(response.package.downloads.total),
+        status: millify(packageMeta.downloads.total),
         color: 'green'
       }
     case 'dd':
       return {
         subject: 'downloads',
-        status: millify(response.package.downloads.daily) + '/day',
+        status: millify(packageMeta.downloads.daily) + '/day',
         color: 'green'
       }
     case 'dm':
       return {
         subject: 'downloads',
-        status: millify(response.package.downloads.monthly) + '/month',
+        status: millify(packageMeta.downloads.monthly) + '/month',
         color: 'green'
       }
     case 'favers':
       return {
         subject: 'favers',
-        status: millify(response.package.favers),
+        status: millify(packageMeta.favers),
         color: 'green'
       }
     case 'dependents':
       return {
         subject: 'dependents',
-        status: millify(response.package.dependents),
+        status: millify(packageMeta.dependents),
         color: 'green'
       }
     case 'suggesters':
       return {
         subject: 'suggesters',
-        status: millify(response.package.suggesters),
+        status: millify(packageMeta.suggesters),
         color: 'green'
       }
     case 'n':
       return {
         subject: 'packagist',
-        status: response.package.name,
+        status: packageMeta.name,
         color: 'green'
       }
     case 'ghs':
       return {
         subject: 'stars',
-        status: millify(response.package.github_stars),
+        status: millify(packageMeta.github_stars),
         color: 'green'
       }
     case 'ghw':
       return {
         subject: 'watchers',
-        status: millify(response.package.github_watchers),
+        status: millify(packageMeta.github_watchers),
         color: 'green'
       }
     case 'ghf':
       return {
         subject: 'forks',
-        status: millify(response.package.github_forks),
+        status: millify(packageMeta.github_forks),
         color: 'green'
       }
     case 'ghi':
       return {
         subject: 'issues',
-        status: millify(response.package.github_open_issues),
+        status: millify(packageMeta.github_open_issues),
         color: 'green'
       }
     case 'lang':
       return {
         subject: 'language',
-        status: response.package.language,
+        status: packageMeta.language,
         color: 'green'
       }
     default:

--- a/libs/live-fns/packagist.js
+++ b/libs/live-fns/packagist.js
@@ -7,7 +7,7 @@ const semColor = require('../utils/sem-color.js')
 const pre = versions => versions.filter(v => v.includes('-') && v.indexOf('dev') !== 0)
 const stable = versions => versions.filter(v => !v.includes('-'))
 const latest = versions => versions.length > 0 && versions.slice(-1)[0]
-const nodev = versions => versions.filter(v => v.indexOf('dev') === -1)
+const noDev = versions => versions.filter(v => v.indexOf('dev') === -1)
 
 module.exports = async function (topic, vendor, pkg, channel = 'stable') {
   const endpoint = `https://packagist.org/packages/${vendor}/${pkg}.json`
@@ -21,7 +21,7 @@ module.exports = async function (topic, vendor, pkg, channel = 'stable') {
 
       switch (channel) {
         case 'latest':
-          version = latest(nodev(versions))
+          version = latest(noDev(versions))
           break
         case 'pre':
           version = latest(pre(versions))

--- a/libs/utils/compare-versions.js
+++ b/libs/utils/compare-versions.js
@@ -1,0 +1,44 @@
+const indexOrEnd = (str, q) => str.indexOf(q) === -1 ? str.length : str.indexOf(q)
+const parseNumber = v => isNaN(Number(v)) ? v : Number(v)
+
+const split = (v) => {
+  var c = v.replace(/^v/, '').replace(/\+.*$/, '')
+  var patchIndex = indexOrEnd(c, '-')
+  var arr = c.substring(0, patchIndex).split('.')
+  arr.push(c.substring(patchIndex + 1))
+  return arr
+}
+
+// See: https://github.com/omichelsen/compare-versions
+module.exports = (v1, v2) => {
+  var s1 = split(v1)
+  var s2 = split(v2)
+
+  for (var i = 0; i < Math.max(s1.length - 1, s2.length - 1); i++) {
+    var n1 = parseInt(s1[i] || 0, 10)
+    var n2 = parseInt(s2[i] || 0, 10)
+
+    if (n1 > n2) return 1
+    if (n2 > n1) return -1
+  }
+
+  var sp1 = s1[s1.length - 1]
+  var sp2 = s2[s2.length - 1]
+
+  if (sp1 && sp2) {
+    var p1 = sp1.split('.').map(parseNumber)
+    var p2 = sp2.split('.').map(parseNumber)
+
+    for (i = 0; i < Math.max(p1.length, p2.length); i++) {
+      if (p1[i] === undefined || (typeof p2[i] === 'string' && typeof p1[i] === 'number')) return -1
+      if (p2[i] === undefined || (typeof p1[i] === 'string' && typeof p2[i] === 'number')) return 1
+
+      if (p1[i] > p2[i]) return 1
+      if (p2[i] > p1[i]) return -1
+    }
+  } else if (sp1 || sp2) {
+    return sp1 ? -1 : 1
+  }
+
+  return 0
+}

--- a/libs/utils/compare-versions.js
+++ b/libs/utils/compare-versions.js
@@ -1,28 +1,11 @@
 const semver = require('semver')
 
 module.exports = (v1, v2) => {
-  const validV1 = semver.valid(v1)
-  const validV2 = semver.valid(v2)
+  const validV1 = semver.valid(semver.coerce(v1))
+  const validV2 = semver.valid(semver.coerce(v2))
 
   const isV1Valid = !!validV1
   const isV2Valid = !!validV2
-
-  if (!isV1Valid && !isV2Valid) {
-    const numberVersionRegex = /^\d/
-    const isV1NumberVersion = numberVersionRegex.test(v1)
-    const isV2NumberVersion = numberVersionRegex.test(v2)
-
-    if (isV1NumberVersion && isV2NumberVersion) {
-      return v1.localeCompare(v2)
-    }
-
-    if (isV1NumberVersion && !isV2NumberVersion) {
-      return 1
-    }
-    if (!isV1NumberVersion && isV2NumberVersion) {
-      return -1
-    }
-  }
 
   if (isV1Valid && isV2Valid) {
     return semver.compare(validV1, validV2)

--- a/libs/utils/compare-versions.js
+++ b/libs/utils/compare-versions.js
@@ -1,44 +1,39 @@
-const indexOrEnd = (str, q) => str.indexOf(q) === -1 ? str.length : str.indexOf(q)
-const parseNumber = v => isNaN(Number(v)) ? v : Number(v)
+const semver = require('semver')
 
-const split = (v) => {
-  var c = v.replace(/^v/, '').replace(/\+.*$/, '')
-  var patchIndex = indexOrEnd(c, '-')
-  var arr = c.substring(0, patchIndex).split('.')
-  arr.push(c.substring(patchIndex + 1))
-  return arr
-}
-
-// See: https://github.com/omichelsen/compare-versions
 module.exports = (v1, v2) => {
-  var s1 = split(v1)
-  var s2 = split(v2)
+  const validV1 = semver.valid(v1)
+  const validV2 = semver.valid(v2)
 
-  for (var i = 0; i < Math.max(s1.length - 1, s2.length - 1); i++) {
-    var n1 = parseInt(s1[i] || 0, 10)
-    var n2 = parseInt(s2[i] || 0, 10)
+  const isV1Valid = !!validV1
+  const isV2Valid = !!validV2
 
-    if (n1 > n2) return 1
-    if (n2 > n1) return -1
-  }
+  if (!isV1Valid && !isV2Valid) {
+    const numberVersionRegex = /^\d/
+    const isV1NumberVersion = numberVersionRegex.test(v1)
+    const isV2NumberVersion = numberVersionRegex.test(v2)
 
-  var sp1 = s1[s1.length - 1]
-  var sp2 = s2[s2.length - 1]
-
-  if (sp1 && sp2) {
-    var p1 = sp1.split('.').map(parseNumber)
-    var p2 = sp2.split('.').map(parseNumber)
-
-    for (i = 0; i < Math.max(p1.length, p2.length); i++) {
-      if (p1[i] === undefined || (typeof p2[i] === 'string' && typeof p1[i] === 'number')) return -1
-      if (p2[i] === undefined || (typeof p1[i] === 'string' && typeof p2[i] === 'number')) return 1
-
-      if (p1[i] > p2[i]) return 1
-      if (p2[i] > p1[i]) return -1
+    if (isV1NumberVersion && isV2NumberVersion) {
+      return v1.localeCompare(v2)
     }
-  } else if (sp1 || sp2) {
-    return sp1 ? -1 : 1
+
+    if (isV1NumberVersion && !isV2NumberVersion) {
+      return 1
+    }
+    if (!isV1NumberVersion && isV2NumberVersion) {
+      return -1
+    }
   }
 
-  return 0
+  if (isV1Valid && isV2Valid) {
+    return semver.compare(validV1, validV2)
+  }
+
+  if (isV1Valid && !isV2Valid) {
+    return 1
+  }
+  if (!isV1Valid && isV2Valid) {
+    return -1
+  }
+
+  return v1.localeCompare(v2)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6716,8 +6716,7 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "semver-store": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "micro": "^9.3.2",
     "micro-fork": "^0.1.0",
     "millify": "^2.0.1",
+    "semver": "^5.5.0",
     "serve-marked": "0.3.0",
     "xml2js": "^0.4.19"
   },


### PR DESCRIPTION
The packagist version detection for `latest` ist currently broken when a package published a patch version for a older minor release. Than this patch version is detected as the latest release (e.g.`v1.0.0` => `v2.0.0` => `v1.0.1`).

This PR adds a `compareVersions` sort function based on [compare-versions](https://github.com/omichelsen/compare-versions) to sort the versions returned from the packagist API before detecting the latest.

Other changes:
- `nodev` filters out every version containing `dev` (e.g. `1.0.x-dev`)
- `pre` filters out versions starting with `dev` (e.g. `dev-master`)
- Some minor code improvements