### PR TITLE
Add brackets extension badges 🎉

### DIFF
--- a/libs/index.md
+++ b/libs/index.md
@@ -164,6 +164,12 @@ Available query params:
       ['version downloads', '/rubygems/dv/rails'],
       ['name', '/rubygems/n/rails'],
       ['platform', '/rubygems/p/rails'],
+    brackets: [
+      ['daily downloads', '/brackets/dd/brackets-emmet'],
+      ['weekly downloads', '/brackets/dw/brackets-emmet'],
+      ['total downloads', '/brackets/dt/brackets-emmet'],
+      ['downloads (latest)', '/brackets/dl/brackets-emmet'],
+      ['version', '/brackets/v/brackets-emmet'],
     ],
     /* CIs */
     travis: [

--- a/libs/index.md
+++ b/libs/index.md
@@ -164,6 +164,7 @@ Available query params:
       ['version downloads', '/rubygems/dv/rails'],
       ['name', '/rubygems/n/rails'],
       ['platform', '/rubygems/p/rails'],
+    ],
     brackets: [
       ['daily downloads', '/brackets/dd/brackets-emmet'],
       ['weekly downloads', '/brackets/dw/brackets-emmet'],

--- a/libs/live-fns/_index.js
+++ b/libs/live-fns/_index.js
@@ -2,6 +2,7 @@
 module.exports = {
   'amo': require('./amo.js'),
   'appveyor': require('./appveyor.js'),
+  'brackets': require('./brackets.js'),
   'bundlephobia': require('./bundlephobia.js'),
   'chrome-web-store': require('./chrome-web-store.js'),
   'circleci': require('./circleci.js'),

--- a/libs/live-fns/brackets.js
+++ b/libs/live-fns/brackets.js
@@ -1,0 +1,91 @@
+const axios = require('../axios.js')
+const cache = require('memory-cache')
+const cron = require('cron')
+const https = require('https')
+const millify = require('millify')
+const semColor = require('../utils/sem-color.js')
+
+/**
+ * Brackets extension statistics cannot be retrieved using a regular API
+ * All the statistics must be extracted from a big file called the 'registry', which contains everything there is
+ * to know about every extension.
+ *
+ * > curl https://brackets-registry.aboutweb.com/registryList -H "Accept: application/json" -k
+ *
+ * The registry is parsed at a regular interval, and extracted data is saved in memory.
+ */
+
+module.exports = async function (topic, pkg) {
+  const ext = cache.get('brackets|' + pkg)
+  if (!ext) {
+    return {subject: 'brackets', status: 'unknown', color: 'grey'}
+  }
+
+  const dlBadge = status => {
+    return {subject: 'downloads', status: status, color: 'green'}
+  }
+
+  switch (topic) {
+    case 'dd':
+      return dlBadge(millify(Math.round(ext.w / 7)) + '/day')
+    case 'dw':
+      return dlBadge(millify(ext.w) + '/week')
+    case 'dt':
+      return dlBadge(millify(ext.t))
+    case 'dl':
+      return dlBadge(millify(ext.l) + ' latest version')
+    case 'v':
+      return {subject: 'version', status: 'v' + ext.v, color: semColor(ext.v)}
+    default:
+      return {subject: 'brackets', status: 'unknown', color: 'grey'}
+  }
+}
+
+// Fetch all data from the brackets registry
+const getData = () => {
+  axios.get('https://brackets-registry.aboutweb.com/registryList', {
+    headers: {Accept: 'application/json'},
+    httpsAgent: new https.Agent({rejectUnauthorized: false})
+  }).then(res => {
+    for (const result of res.data.registry) {
+      const lastVersion = result.versions ? result.versions[result.versions.length - 1] : {}
+      const weekDownloads = result.recent ? getWeekDownloads(result.recent) : 0
+
+      cache.put('brackets|' + result.metadata.name, {
+        w: weekDownloads,
+        t: result.totalDownloads || 0,
+        l: lastVersion.downloads || 0,
+        v: lastVersion.version || ''
+      })
+    }
+    console.info('#brackets retrieved ' + res.data.registry.length + ' extensions from the brackets registry')
+  }, err => {
+    console.error('#brackets error retrieving brackets data:', err)
+  })
+}
+
+// Parse the 'recent' object and extract last week's downloads
+function getWeekDownloads (recent) {
+  let keys = Object.keys(recent)
+  let last = keys[keys.length - 1]
+  let day = new Date(last.substring(0, 4) + '-' + last.substring(4, 6) + '-' + last.substring(6, 8))
+  let count = 0
+  for (let x = 0; x < 7; x++) {
+    const mm = day.getMonth() + 1
+    const dd = day.getDate()
+    const key = [day.getFullYear(), (mm > 9 ? '' : '0') + mm, (dd > 9 ? '' : '0') + dd].join('')
+    count += recent[key] ? recent[key] : 0
+    day.setDate(day.getDate() - 1)
+  }
+  return count
+}
+
+// Fetch data every 2 hours
+const job = new cron.CronJob('0 */2 * * *', () => getData())
+
+// Initialisation
+if (!cache.get('brackets_started')) {
+  cache.put('brackets_started', true)
+  getData()
+  job.start()
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -780,6 +780,14 @@
         }
       }
     },
+    "cron": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-1.3.0.tgz",
+      "integrity": "sha512-K/SF7JlgMmNjcThWxkKvsHhey2EDB4CeOEWJ9aXWj3fbQJppsvTPIeyLdHfNq5IbbsMUUjRW1nr5dSO95f2E4w==",
+      "requires": {
+        "moment-timezone": "^0.5.x"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -3062,6 +3070,11 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -3273,6 +3286,19 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+    },
+    "moment-timezone": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
+      "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
+      "requires": {
+        "moment": ">= 2.9.0"
       }
     },
     "mri": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "byte-size": "^4.0.3",
     "cheerio": "^1.0.0-rc.2",
     "chrome-webstore": "^1.0.0",
+    "cron": "^1.3.0",
+    "memory-cache": "^0.2.0",
     "micro": "^9.3.2",
     "micro-fork": "^0.1.0",
     "millify": "^2.0.1",


### PR DESCRIPTION
In winter 2017, I created [brackets-extension-badges.github.io](https://brackets-extension-badges.github.io/) and a [badge-provider](https://github.com/brackets-extension-badges/badge-provider-nodejs) with only one simple goal: generating badges for [Adobe brackets](http://brackets.io/) extension creators (I am one of them)

I feel like this is a good time to stop my lonely project and use **badgen** to serve that purpose.
The two projects have a few similarities: they both compute text width with a prebuilt char-width table, and both are hosted by Now Cloud ([badges.ml](https://zeit.co/bokub/badge-provider/rkmdchyvoc/source))

But there is a catch 🙁 
Brackets extension statistics cannot be retrieved using a regular API (thanks Adobe!)
All the statistics must be extracted from a big file called the 'registry', which contains everything there is to know about every extension.

You can preview this registry by running 

```sh
curl https://brackets-registry.aboutweb.com/registryList -H "Accept: application/json" -k
```
As you can see in my code, the registry needs to be parsed on startup, then at a regular interval (2 hours seems reasonable).

The interesting data is saved in memory, and retrieved on a badge request.

Because of that, 2 new dependencies are required, so I would totally understand if you declined my pull request.

Tell me what you think ! :+1: