### PR TITLE
Add apm

### DIFF
--- a/libs/index.md
+++ b/libs/index.md
@@ -227,6 +227,12 @@ Available query params:
       ['contributors', '/opencollective/contributors/webpack'],
       ['balance', '/opencollective/balance/webpack'],
       ['yearly income', '/opencollective/yearly/webpack'],
+    ],
+    'apm': [
+      ['version', '/apm/v/linter'],
+      ['license', '/apm/license/linter'],
+      ['downloads', '/apm/dl/linter'],
+      ['stars', '/apm/stars/linter'],
     ]
   }
 

--- a/libs/live-fns/_index.js
+++ b/libs/live-fns/_index.js
@@ -1,6 +1,7 @@
 /* eslint sort-keys: "error" */
 module.exports = {
   'amo': require('./amo.js'),
+  'apm': require('./apm.js'),
   'appveyor': require('./appveyor.js'),
   'bundlephobia': require('./bundlephobia.js'),
   'chrome-web-store': require('./chrome-web-store.js'),

--- a/libs/live-fns/apm.js
+++ b/libs/live-fns/apm.js
@@ -1,0 +1,68 @@
+const millify = require('millify')
+const axios = require('../axios.js')
+
+// https://atom.io/api/packages/*
+
+module.exports = async function apm (topic, ...args) {
+  switch (topic) {
+    case 'v':
+      return pkg('version', args)
+    case 'dl':
+      return pkg('downloads', args)
+    case 'license':
+      return pkg('license', args)
+    case 'stars':
+      return pkg('stars', args)
+    default:
+      return {
+        subject: 'apm',
+        status: 'unknown',
+        color: 'grey'
+      }
+  }
+}
+
+async function pkg (topic, args) {
+  let pkg = args[0]
+
+  const endpoint = `https://atom.io/api/packages/${pkg}`
+  const meta = await axios.get(endpoint).then(res => res.data)
+
+  switch (topic) {
+    case 'version': {
+      return {
+        subject: `apm`,
+        status: `v${meta.releases.latest}` || 'unknown',
+        color: 'green'
+      }
+    }
+    case 'license': {
+      return {
+        subject: 'license',
+        status: meta.versions[meta.releases.latest].license || 'unknown',
+        color: 'blue'
+      }
+    }
+    case 'downloads': {
+      return {
+        subject: 'downloads',
+        status: millify(meta.downloads) || 'unknown',
+        color: 'green'
+      }
+    }
+    case 'stars': {
+      return {
+        subject: 'stars',
+        status: millify(meta.stargazers_count) || 'unknown',
+        color: 'green'
+      }
+    }
+    default: {
+      return {
+        subject: 'apm',
+        status: 'unknown',
+        color: 'grey'
+      }
+    }
+  }
+}


### PR DESCRIPTION
`apm` is the package manager for Atom and - as far as I kow – a fork of `npm`. Hence, this PR is largely based on `npm.js`.