### PR TITLE
Add packagist license badge

### DIFF
--- a/libs/index.md
+++ b/libs/index.md
@@ -155,6 +155,7 @@ Available query params:
       ['github forks', '/packagist/ghf/monolog/monolog'],
       ['github issues', '/packagist/ghi/monolog/monolog'],
       ['language', '/packagist/lang/monolog/monolog'],
+      ['license', '/packagist/license/monolog/monolog'],
     ],
     rubygems: [
       ['version (stable)', '/rubygems/v/rails'],

--- a/libs/live-fns/packagist.js
+++ b/libs/live-fns/packagist.js
@@ -8,6 +8,7 @@ const pre = versions => versions.filter(v => v.includes('-') && v.indexOf('dev')
 const stable = versions => versions.filter(v => !v.includes('-'))
 const latest = versions => versions.length > 0 && versions.slice(-1)[0]
 const noDev = versions => versions.filter(v => v.indexOf('dev') === -1)
+const license = versions => Object.values(versions).find(v => v.license.length > 0).license[0]
 
 module.exports = async function (topic, vendor, pkg, channel = 'stable') {
   const endpoint = `https://packagist.org/packages/${vendor}/${pkg}.json`
@@ -102,6 +103,12 @@ module.exports = async function (topic, vendor, pkg, channel = 'stable') {
         subject: 'issues',
         status: millify(packageMeta.github_open_issues),
         color: 'green'
+      }
+    case 'license':
+      return {
+        subject: 'license',
+        status: license(packageMeta.versions) || 'unknown',
+        color: 'blue'
       }
     case 'lang':
       return {


### PR DESCRIPTION
This pull request add support for Packagist license. Not sure if you want to go with `license` or `l`. I've chosen `license` to be consistent with npm and pypi.