### PR TITLE
live-fns: (github) refactor & use `got`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,11 @@
+version: "2"
+checks:
+  method-complexity:
+    config:
+      threshold: 8
+  method-lines:
+    config:
+      threshold: 100
+  file-lines:
+    config:
+      threshold: 500

--- a/libs/index.md
+++ b/libs/index.md
@@ -109,7 +109,7 @@ Available query params:
       ['tags', '/github/tags/micromatch/micromatch'],
       ['license', '/github/license/micromatch/micromatch'],
       ['last commit', '/github/last-commit/micromatch/micromatch'],
-      ['total downloads', '/github/dt/electron/electron'],
+      ['latest assets downloads', '/github/dl/electron/electron'],
       ['repository dependents', '/github/dependents-repo/micromatch/micromatch'],
       ['package dependents', '/github/dependents-pkg/micromatch/micromatch']
     ],

--- a/libs/index.md
+++ b/libs/index.md
@@ -109,7 +109,7 @@ Available query params:
       ['tags', '/github/tags/micromatch/micromatch'],
       ['license', '/github/license/micromatch/micromatch'],
       ['last commit', '/github/last-commit/micromatch/micromatch'],
-      ['latest assets downloads', '/github/dl/electron/electron'],
+      ['latest assets downloads', '/github/assets-dl/electron/electron'],
       ['repository dependents', '/github/dependents-repo/micromatch/micromatch'],
       ['package dependents', '/github/dependents-pkg/micromatch/micromatch']
     ],

--- a/libs/live-fetcher.js
+++ b/libs/live-fetcher.js
@@ -14,7 +14,8 @@ module.exports = async (scope, fn, paramsPath) => {
       status = 'timeout'
     }
 
-    console.error(fetchKey, `LIVEFN_ERR<${status}>`, e.message)
+    const info = status === 'unknown' ? e.stack : e.message
+    console.error(fetchKey, `LIVEFN_ERR<${status}>`, info)
     return { status, failed: true }
   }).then(result => {
     console.timeEnd(fetchKey)


### PR DESCRIPTION
- Replace `axios` with `got`
- Separate assets downloads count, usage `/dt/` => `/assets-dl/`
- Split `stats()` into resoStats, makeRepoQuery, repoQueryBodies

Make codeclimate happy.