### PR TITLE
Retrieve trackingGA from env

### DIFF
--- a/libs/serve-docs.js
+++ b/libs/serve-docs.js
@@ -16,7 +16,7 @@ const serveMarkedOptions = {
     p img + a { vertical-align: top; margin-left: 0.4em; font: 14px/20px monospace }
   `,
   beforeHeadEnd: `<link rel="icon" type="image/svg+xml" href="/favicon.svg">`,
-  trackingGA: 'UA-4646421-14'
+  trackingGA: process.env.TRACKING_GA || null
 }
 
 const docsFolder = path.join(__dirname, 'docs')

--- a/libs/serve-index.js
+++ b/libs/serve-index.js
@@ -68,5 +68,5 @@ module.exports = serveMarked('libs/index.md', {
       </div>
     </div>
   `,
-  trackingGA: 'UA-4646421-14'
+  trackingGA: process.env.TRACKING_GA || null
 })

--- a/now.json
+++ b/now.json
@@ -12,7 +12,7 @@
   ],
   "env": {
     "GH_TOKEN": "@badgen-gh-token",
-    "TRACKING_GA": "@tracking-ga"
+    "TRACKING_GA": "@badgen-tracking-ga"
   },
   "engines": {
     "node": "^10.0.0"

--- a/now.json
+++ b/now.json
@@ -11,7 +11,8 @@
     "libs"
   ],
   "env": {
-    "GH_TOKEN": "@badgen-gh-token"
+    "GH_TOKEN": "@badgen-gh-token",
+    "TRACKING_GA": "@tracking-ga"
   },
   "engines": {
     "node": "^10.0.0"


### PR DESCRIPTION
Right now, badgen is using a fixed Google Analytics tracking ID.
This ID is used by forks of badgen, as well as local versions running on a dev server, which tend to alter real statistics from `badgen.net`.

This ID should be used only in production, and maybe you'd like to change it later without editing your code.

Maybe you can add your tracking ID as a secret : 

```sh
now secrets add tracking-ga "UA-4646421-14"
```