### PR TITLE
fix useless conditional in david.js

### DIFF
--- a/libs/live-fns/david.js
+++ b/libs/live-fns/david.js
@@ -15,7 +15,7 @@ module.exports = async (depType, user, repo, ...path) => {
     peer: 'peer-',
     optional: 'optional-'
   }[depType]
-  const query = path ? `?path=${path.join('/')}` : ''
+  const query = path.length ? `?path=${path.join('/')}` : ''
   const endpoint = `https://david-dm.org/${user}/${repo}/${prefix}info.json${query}`
   const { status } = await axios.get(endpoint).then(res => res.data)
 


### PR DESCRIPTION
This PR fixes the [only alert produced by LGTM](https://lgtm.com/projects/g/amio/badgen-service/alerts/?mode=list).

The problem is a little subtle, the truthyness of `path` will always be `true` because the truthyness of an empty array is `true` (`!![] == true` even though `[] == false`): https://www.nfriedly.com/techblog/2009/07/advanced-javascript-operators-and-truthy-falsy/

So a path will always be added to the query, even if no path arguments were given, resulting in `?path=` being added to the end. This corrects the condition so that no path is added to the query if it's empty.