### PR TITLE
icons: automatically populate list in index.md

### DIFF
--- a/libs/index.md
+++ b/libs/index.md
@@ -288,8 +288,10 @@ Advanced usage (for badge makers):
   fetch('/metadata.json')
     .then((resp) => resp.json())
     .then(json => {
+      const blacklist = ['npm-red', 'postgresql', 'discord', 'lgtm']
       const icons = document.querySelector('#icon-examples')
       for (const icon of json.icons) {
+        if (blacklist.indexOf(icon) !== -1) continue;
         const img = document.createElement('img')
         img.src = `/badge//${icon}?icon=${icon}`
         icons.appendChild(img)

--- a/libs/index.md
+++ b/libs/index.md
@@ -32,35 +32,7 @@ Available color names:
 
 Available icons:
 
-![](/badge//airbnb?icon=airbnb)
-![](/badge//apple?icon=apple)
-![](/badge//appveyor?icon=appveyor)
-![](/badge//atom?icon=atom)
-![](/badge//chrome?icon=chrome)
-![](/badge//circleci?icon=circleci)
-![](/badge//codeclimate?icon=codeclimate)
-![](/badge//codecov?icon=codecov)
-![](/badge//codeship?icon=codeship)
-![](/badge//dependabot?icon=dependabot)
-![](/badge//dockbit?icon=dockbit)
-![](/badge//docker?icon=docker)
-![](/badge//eclipse?icon=eclipse)
-![](/badge//firefox?icon=firefox)
-![](/badge//github?icon=github)
-![](/badge//gitlab?icon=gitlab)
-![](/badge//gitter?icon=gitter)
-![](/badge//graphql?icon=graphql)
-![](/badge//haskell?icon=haskell)
-![](/badge//npm?icon=npm)
-![](/badge//patreon?icon=patreon)
-![](/badge//ruby?icon=ruby)
-![](/badge//scrutinizer?icon=scrutinizer)
-![](/badge//slack?icon=slack)
-![](/badge//sourcegraph?icon=sourcegraph)
-![](/badge//terminal?icon=terminal)
-![](/badge//travis?icon=travis)
-![](/badge//twitter?icon=twitter)
-![](/badge//windows?icon=windows)
+<div id="icon-examples"></div>
 
 Available query params:
 
@@ -309,6 +281,21 @@ Advanced usage (for badge makers):
       'flat.badgen.net'
     ).replace(/\n/g, '\n     ')
   }
+</script>
+
+<script>
+  // Generate the icons example
+  fetch('/metadata.json')
+    .then((resp) => resp.json())
+    .then(json => {
+      const icons = document.querySelector('#icon-examples')
+      for (const icon of json.icons) {
+        const img = document.createElement('img')
+        img.src = `/badge//${icon}?icon=${icon}`
+        icons.appendChild(img)
+        icons.appendChild(document.createTextNode("\n"))
+      }
+  })
 </script>
 
 <script type="module">

--- a/libs/serve-metadata.js
+++ b/libs/serve-metadata.js
@@ -1,0 +1,13 @@
+const { send } = require('micro')
+const { builtin } = require('./icons.js')
+
+module.exports = (req, res) => {
+  const code = 200
+
+  const info = {
+    icons: Object.keys(builtin)
+  }
+
+  res.setHeader('Content-Type', 'application/json')
+  send(res, code, JSON.stringify(info))
+}

--- a/service.js
+++ b/service.js
@@ -5,6 +5,7 @@ const serveIndex = require('./libs/serve-index.js')
 const serve404 = require('./libs/serve-404.js')
 const serveDocs = require('./libs/serve-docs.js')
 const serveBadge = require('./libs/serve-badge.js')
+const serveMetadata = require('./libs/serve-metadata.js')
 const liveHandlers = require('./libs/live-handlers.js')
 const serveApi = require('./libs/serve-api.js')
 const raven = require('./libs/raven.js')
@@ -25,6 +26,7 @@ const serveStaticBadge = (req, res) => {
 const main = router()(
   get('/*', serve404),
   get('/', indexHandler),
+  get('/metadata.json', serveMetadata),
   get('/static/*', serveStatic),
   get('/docs/:topic', serveDocs),
   get('/badge/:subject/:status', serveStaticBadge),


### PR DESCRIPTION
After opening #128, but before seeing #99, I was thinking that it would be a good idea to automatically populate the list of icons on the homepage, rather than having to maintain the list there, and remembering to add icons each time a new one is added.

After seeing that some are deliberately not on there, I think this still could be useful now i've added a blacklist, and will self-document the fact that some badges have deliberately been chosen not to be on there, and avoid any further confusion of users introducing PRs like #128 and #99.