### PR TITLE
docs: add lgtm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ At the time of badgen.now.sh's reveal, it had only four live badges as demonstra
 [![StandardJS][standard-src]][standard-href]
 [![Dependencies][dependencies-src]][dependencies-href]
 [![Maintainability][maintainability-src]][maintainability-href]
+[![Code Quality][codequality-src]][codequality-href]
+[![LGTM Alerts][alerts-src]][alerts-href]
 [![Contributors][contributors-src]][contributors-href]
 [![Deploy to Now][deploy-to-now-src]](#deploy-to-now)
 
@@ -98,6 +100,10 @@ built with ⚡️ from [badgen](https://github.com/amio/badgen).
 [deploy-to-now-src]: https://badgen.net/badge/▲/$%20now%20amio%2Fbadgen-service/333
 [maintainability-src]: https://badgen.net/codeclimate/maintainability/amio/badgen-service
 [maintainability-href]: https://codeclimate.com/github/amio/badgen-service
+[codequality-src]: https://badgen.net/lgtm/grade/javascript/g/amio/badgen-service?icon=lgtm
+[codequality-href]: https://lgtm.com/projects/g/amio/badgen-service/context:javascript
+[alerts-src]: https://badgen.net/lgtm/alerts/g/amio/badgen-service?icon=lgtm
+[alerts-href]: https://lgtm.com/projects/g/amio/badgen-service/alerts/
 [contributors-src]: https://badgen.net/github/contributors/amio/badgen-service
 [contributors-href]: https://github.com/amio/badgen-service/graphs/contributors
 [now-href]: https://zeit.co/now

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ built with ⚡️ from [badgen](https://github.com/amio/badgen).
 [deploy-to-now-src]: https://badgen.net/badge/▲/$%20now%20amio%2Fbadgen-service/333
 [maintainability-src]: https://badgen.net/codeclimate/maintainability/amio/badgen-service
 [maintainability-href]: https://codeclimate.com/github/amio/badgen-service
-[codequality-src]: https://badgen.net/lgtm/grade/javascript/g/amio/badgen-service?icon=lgtm
+[codequality-src]: https://badgen.net/lgtm/grade/javascript/g/amio/badgen-service
 [codequality-href]: https://lgtm.com/projects/g/amio/badgen-service/context:javascript
-[alerts-src]: https://badgen.net/lgtm/alerts/g/amio/badgen-service?icon=lgtm
+[alerts-src]: https://badgen.net/lgtm/alerts/g/amio/badgen-service
 [alerts-href]: https://lgtm.com/projects/g/amio/badgen-service/alerts/
 [contributors-src]: https://badgen.net/github/contributors/amio/badgen-service
 [contributors-href]: https://github.com/amio/badgen-service/graphs/contributors


### PR DESCRIPTION
Now that the lgtm service is added, the logo has a custom width, and badgen-service's alerts are down to 0, time to add badges to the README? :-D

Also, @amio would you like to enable the pull request integration here to help prevent new alerts appearing? https://lgtm.com/projects/g/amio/badgen-service/ci/