### PR TITLE
Override badge color

### DIFF
--- a/libs/index.md
+++ b/libs/index.md
@@ -11,7 +11,7 @@ Fast badge generating service.
 ```
 https://badgen.net/badge/:subject/:status/:color?icon=github
                    ──┬──  ───┬───  ──┬───  ──┬── ────┬──────
-                     │       │       │       │       └─ Advanced Options (label, list, icon)
+                     │       │       │       │       └─ Advanced Options (label, list, icon, color)
                      │       │       │       │
                      │      TEXT    TEXT    RGB / COLOR_NAME ( optional )
                      │
@@ -39,6 +39,7 @@ Available query params:
 - `icon` Use builtin icon in front of subject text. [e.g.][icon-eg-href]
 - `list` Set `list=1` will replace `,` with ` | ` in status text. [e.g.][list-eg-href]
 - `label` Override default subject text ([URL-Encoding][url-enc-href] needed for spaces or special characters).
+- `color` Override badge color. [e.g.][color-eg-href]
 
 Advanced usage (for badge makers):
 
@@ -346,3 +347,4 @@ Advanced usage (for badge makers):
 [style-eg-href]: /badge/color/blue/blue?style=flat
 [list-eg-href]: /badge/platform/ios,macos,tvos?list=1
 [icon-eg-href]: /badge/docker/v1.2.3/blue?icon=docker
+[color-eg-href]: /npm/dm/express?color=pink

--- a/libs/serve-badge.js
+++ b/libs/serve-badge.js
@@ -13,12 +13,12 @@ module.exports = (req, res, options = {}) => {
 
   const hostStyle = req.headers.host === 'flat.badgen.net' ? 'flat' : undefined
   const { subject, status, color } = req.params
-  const { style, label, list, icon, iconWidth } = req.query
+  const { style, label, list, icon, iconWidth, color: queryColor } = req.query
 
   const badge = badgen({
     subject: typeof label !== 'undefined' ? label : subject,
     status: String(list ? status.replace(/,/g, ' | ') : status),
-    color: color,
+    color: queryColor || color,
     style: style || hostStyle,
     emoji: true,
     icon: builtin[icon],


### PR DESCRIPTION
I'd love to be able to override a live badge color, for example having my npm download count in pink, or my license badge in some weird color I like.

This PR adds an optional 'color' option to the badge handler (live & static), which supports color names and hex strings.

E.g:  
- ![Badge](https://badgen-service-artxnvyutq.now.sh/npm/dm/express?color=pink)  `/npm/dm/express?color=pink`
- ![Badge](https://badgen-service-artxnvyutq.now.sh/npm/license/lodash?color=9ea7f9
)  `/npm/license/lodash?color=9ea7f9`
