### PR TITLE
Add yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn.lock


### PR DESCRIPTION
Stop yarn users accidentally committing `yarn.lock`, i.e https://github.com/amio/badgen-service/pull/141/#issuecomment-418692447