### PR TITLE
Change david-dm to green w/zero deps

### DIFF
--- a/libs/live-fns/david.js
+++ b/libs/live-fns/david.js
@@ -5,7 +5,7 @@ const statusInfo = {
   outofdate: ['out of date', 'orange'],
   notsouptodate: ['up to date', 'yellow'],
   uptodate: ['up to date', 'green'],
-  none: ['none', 'blue']
+  none: ['none', 'green']
 }
 
 module.exports = async (depType, user, repo, ...path) => {


### PR DESCRIPTION
I like to add the `/david/dev` and `/david/dep` to all projects and it looks a little odd when they are not both green.

My subjective opinion is that zero dependencies should be considered "passing" (up to date) and should be green, not blue.