### PR TITLE
github tag got the first instead of last

### DIFF
--- a/libs/live-fns/github.js
+++ b/libs/live-fns/github.js
@@ -184,7 +184,7 @@ const repoQueryBodies = {
   'branches': 'refs(first: 0, refPrefix: "refs/heads/") { totalCount }',
   'releases': 'releases { totalCount }',
   'tags': 'refs(first: 0, refPrefix: "refs/tags/") { totalCount }',
-  'tag': `refs(first: 1, refPrefix: "refs/tags/") {
+  'tag': `refs(last: 1, refPrefix: "refs/tags/") {
     edges {
       node {
         name


### PR DESCRIPTION
When using the 'tag' option to get the latest tag - it gets the oldest (first) tag instead of the latest one.
This PR fixes this.